### PR TITLE
Save cache before blt-build

### DIFF
--- a/src/jobs/build-deploy-acsf.yml
+++ b/src/jobs/build-deploy-acsf.yml
@@ -98,8 +98,6 @@ steps:
       name: SSH Disable Host Key Checking
       command: |
         echo "StrictHostKeyChecking=no">> ~/.ssh/config
-  - blt-build:
-      tag: << parameters.tag >>
   - when:
       condition: <<parameters.with_cache>>
       steps:
@@ -117,6 +115,8 @@ steps:
               - docroot/themes/custom/voa/node_modules
               - docroot/themes/custom/voa_admin/node_modules
               - docroot/themes/custom/voa_amp/node_modules
+  - blt-build:
+      tag: << parameters.tag >>
   - blt-deploy:
       tag: << parameters.tag >>
       env: << parameters.acsf-env >>

--- a/src/jobs/build-deploy-acsf.yml
+++ b/src/jobs/build-deploy-acsf.yml
@@ -79,6 +79,13 @@ steps:
         echo "export PATH=`pwd`/vendor/bin:$PATH" >> $BASH_ENV
         source $BASH_ENV
   - checkout
+  - add_ssh_keys:
+      fingerprints:
+        - << parameters.acsf-fingerprints >>
+  - run:
+      name: SSH Disable Host Key Checking
+      command: |
+        echo "StrictHostKeyChecking=no">> ~/.ssh/config
   - when:
       condition: <<parameters.with_cache>>
       steps:
@@ -91,13 +98,17 @@ steps:
         - restore_cache:
             keys:
               - <<parameters.cache_version>>-composer-{{ checksum "composer.lock" }}
-  - add_ssh_keys:
-      fingerprints:
-        - << parameters.acsf-fingerprints >>
   - run:
-      name: SSH Disable Host Key Checking
+      name: Install dependencies
       command: |
-        echo "StrictHostKeyChecking=no">> ~/.ssh/config
+        composer install \
+          --no-interaction \
+          --no-progress
+  - run:
+      name: Install custom themes nodejs dependencies recursively.
+      command: |
+        cd docroot/themes/custom && \
+        find . -name package.json -not -path "*/node_modules/*" -exec bash -c "npm --prefix \$(dirname {}) install" \;
   - when:
       condition: <<parameters.with_cache>>
       steps:


### PR DESCRIPTION
Since the blt-build step uses... blt we should install dependencies before
Adds composer install command, and bash command to install nodejs dependencies recursively for all custom themes