### PR TITLE
[semver:minor] Compare commit sha for tags instead of tag name

### DIFF
--- a/src/scripts/compare-tags.sh
+++ b/src/scripts/compare-tags.sh
@@ -35,7 +35,7 @@ get-current-tag() {
 
 }
 
-# Compare the commit SHA the tags points to, to make sure they are different.
+# Compare the commit SHA the tags points to, to make sure they are truly different.
 compare-tag-commits() {
   CURRENT_TAG=$(get-current-tag)
   echo "Current Tag on ${ACSF_ENV}: $CURRENT_TAG"


### PR DESCRIPTION
There could be situations where two tags with different names points to the same commit (ie: the tags are the same, same code, etc...) in these cases, we should make sure we are comparing the tag "contents", sort to say, and not the tag name.


I've modified the script to get the commit SHA the Tag points to (`git rev-list -n 1 "$TAG"`) and then compare the commit SHA between "current" tag and "to deploy" tag. If these are the same, then we stop the deployment, if these differ, then we continue with the following steps.