### PR TITLE
[semver:minor] Add acsf-verify

### DIFF
--- a/src/commands/blt-build.yml
+++ b/src/commands/blt-build.yml
@@ -11,7 +11,6 @@ steps:
       name: ACSF Verify Tag
       command: |
         vendor/bin/drush --include="./docroot/modules/contrib/acsf/acsf_init" acsf-init-verify
-        echo "$?"
   - run:
       name: BLT build
       command: |

--- a/src/commands/blt-build.yml
+++ b/src/commands/blt-build.yml
@@ -5,8 +5,13 @@ parameters:
     type: string
     default: build-v1.0.$CIRCLE_BUILD_NUM
     description: 'The tag name to build.'
-# TO-DO: Add a "segment" param to increment the tag following semver and be more flexible.
 steps:
+#TO-DO: Make this step conditional with a custom parameter?
+  - run:
+      name: ACSF Verify Tag
+      command: |
+        vendor/bin/drush --include="./docroot/modules/contrib/acsf/acsf_init" acsf-init-verify
+        echo "$?"
   - run:
       name: BLT build
       command: |


### PR DESCRIPTION
Just adds the drush command from `acsf` : 
```
drush acsf-init-verify
```
Before the `BLT build` step. Hopefully that's enough so when the tag is not valid, the step will fail and the build will not be run., notifying users about the failure so they can manually correct and re-commit.

I've added a to-do comment for when we have some time, to make this step conditional.