### PR TITLE
[semver:patch] Jira project filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ This command receives the following parameters to performs the API calls:
   deployments.
 - `acsf-user`: Sets the acsf user account.
 - `acsf-site`: Sets the project site. You can get this value looking at your acsf url: `https://www.[env]-[site].acsitefactory.com`
+- `slack-channel`: The Slack Channel to send notifications.
+- `with-jira`: Boolean. If set to "true" it will transition tickets on the Jira project.
+- `jira-transition-id`: The Jira transition ID.
+- `jira-url`: The Jira Cloud URL
+- `jira-project`: The Jira Project key for which we should transition tickets.
 
 **NOTE**: To perform API calls to the site factory is recommended to create a "machine" user in the site factory
 (in each environment!). This user should have the role "release engineer" to have the correct permissions to use the
@@ -78,6 +83,7 @@ This command receives the following parameters:
 - `env`: The environment where to deploy. It's default value is "test"
 - `jira-url`: The Jira Cloud URL
 - `jira-transition-id`: The Jira transition ID
+- `jira-project`: The Jira project key, to transition only tickets in the specified project.
 
 **NOTE:** To avoid setting the auth token in your config files, you must define it as an CircleCI Environment Variable.
 

--- a/src/commands/jira-transition.yml
+++ b/src/commands/jira-transition.yml
@@ -25,10 +25,14 @@ parameters:
   jira-transition-id:
     type: string
     default: ""
-    description: "The Jira transition ID"
+    description: 'The Jira transition ID'
   jira-auth:
     type: env_var_name
     default: JIRA_AUTH
+  jira-project:
+    type: string
+    default: ""
+    description: 'The Jira Project key for which we should transition tickets.'
 steps:
   - run:
       when: on_success
@@ -41,4 +45,5 @@ steps:
         JIRA_URL: << parameters.jira-url >>
         JIRA_TRANS_ID: << parameters.jira-transition-id >>
         JIRA_AUTH_TOKEN: "$<< parameters.jira-auth >>"
+        JIRA_PROJECT: <<  parameters.jira-project >>
       command: <<include(scripts/jira-transition.sh)>>

--- a/src/examples/use_acsf_jobs.yml
+++ b/src/examples/use_acsf_jobs.yml
@@ -20,6 +20,9 @@ usage:
             acsf-env: "test"
             acsf-deploy-type: "code, db"
             slack-channel: "@your_channel"
+            jira-transition-id: "3"
+            jira-url: "https://your.jira.url"
+            jira-project: "ABC"
             img-version: "latest"
             requires:
               - approve-deployment

--- a/src/jobs/deploy-tag.yml
+++ b/src/jobs/deploy-tag.yml
@@ -40,6 +40,10 @@ parameters:
     default: ""
     type: string
     description: 'The Jira Cloud URL'
+  jira-project:
+    default: ""
+    type: string
+    description: 'The Jira Project key for which we should transition tickets.'
   tag:
     default: $CIRCLE_TAG
     type: string
@@ -73,6 +77,7 @@ steps:
             acsf-site: << parameters.acsf-site >>
             jira-transition-id: << parameters.jira-transition-id >>
             jira-url: << parameters.jira-url >>
+            jira-project: << parameters.jira-project >>
   - slack/notify:
       event: pass
       channel: << parameters.slack-channel >>
@@ -112,6 +117,10 @@ steps:
                             {
                                 "type": "mrkdwn",
                                 "text": "*Tag:*\n<< parameters.tag >>"
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Jira Project:*\n$JIRA_PROJECT"
                             },
                             {
                                 "type": "mrkdwn",


### PR DESCRIPTION
- Adds a new parameter `jira-project` to the jira-transition command AND deploy Job. So we are able to filter the ISSUE_KEYS per Jira project. Avoiding trying to transition other projects issues :innocent: 
- Also updated docs and added examples.