### PR TITLE
[semver:patch] - Adds new param to the deploy Job (which executes the transition command).

### DIFF
--- a/src/commands/blt-build.yml
+++ b/src/commands/blt-build.yml
@@ -5,8 +5,12 @@ parameters:
     type: string
     default: build-v1.0.$CIRCLE_BUILD_NUM
     description: 'The tag name to build.'
-# TO-DO: Add a "segment" param to increment the tag following semver and be more flexible.
 steps:
+#TO-DO: Make this step conditional with a custom parameter?
+  - run:
+      name: ACSF Verify Tag
+      command: |
+        vendor/bin/drush --include="./docroot/modules/contrib/acsf/acsf_init" acsf-init-verify
   - run:
       name: BLT build
       command: |

--- a/src/examples/use_acsf_jobs.yml
+++ b/src/examples/use_acsf_jobs.yml
@@ -20,5 +20,6 @@ usage:
             acsf-env: "test"
             acsf-deploy-type: "code, db"
             slack-channel: "@your_channel"
+            img-version: "latest"
             requires:
               - approve-deployment

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,5 +1,6 @@
-description: >
-  This the Drupal Stand CI.
+description: |
+  Drupal Stand CI. Please select the version of DrupalStand to use.
+  Any available tag from this list can be used: https://hub.docker.com/r/mobomo/drupalstand-ci/tags
 docker:
   - image: 'mobomo/drupalstand-ci:<< parameters.tag >>'
 parameters:

--- a/src/jobs/build-release-tag.yml
+++ b/src/jobs/build-release-tag.yml
@@ -1,7 +1,9 @@
 description: >
   Builds a release tag using BLT commands
 
-executor: default
+executor:
+  name: default
+  tag: << parameters.img-version >>
 
 parameters:
   acsf-fingerprints:
@@ -52,6 +54,12 @@ parameters:
     description: A path to save/restore in cache
     type: string
     default: ""
+  img-version:
+    default: latest
+    description: >
+      Pick a specific mobomo/drupalstand-ci image variant:
+      https://hub.docker.com/r/mobomo/drupalstand-ci/tags.
+    type: string
 environment:
   BASH_ENV: /etc/profile
 steps:

--- a/src/jobs/deploy-tag.yml
+++ b/src/jobs/deploy-tag.yml
@@ -1,7 +1,9 @@
 description: >
   Deploys a pushed tag to the specified environment.
 
-executor: default
+executor:
+  name: default
+  tag: << parameters.img-version >>
 
 parameters:
   acsf-user:
@@ -42,6 +44,12 @@ parameters:
     default: $CIRCLE_TAG
     type: string
     description: 'Tag to be deployed'
+  img-version:
+    default: latest
+    description: >
+      Pick a specific mobomo/drupalstand-ci image variant:
+      https://hub.docker.com/r/mobomo/drupalstand-ci/tags
+    type: string
 steps:
   - checkout
   - compare-tags:

--- a/src/scripts/compare-tags.sh
+++ b/src/scripts/compare-tags.sh
@@ -35,7 +35,7 @@ get-current-tag() {
 
 }
 
-# Compare the commit SHA the tags points to, to make sure they are different.
+# Compare the commit SHA the tags points to, to make sure they are truly different.
 compare-tag-commits() {
   CURRENT_TAG=$(get-current-tag)
   echo "Current Tag on ${ACSF_ENV}: $CURRENT_TAG"

--- a/src/scripts/compare-tags.sh
+++ b/src/scripts/compare-tags.sh
@@ -34,12 +34,24 @@ get-current-tag() {
     -u "${ACSF_USER}":"${ACQUIA_KEY}" | jq -r '.current' | sed 's/tags\///'
 
 }
-CURRENT_TAG=$(get-current-tag)
-echo "Current Tag on ${ACSF_ENV}: $CURRENT_TAG"
-echo "The tag to deploy is $TAG_TO_DEPLOY"
 
-if [ "$TAG_TO_DEPLOY" == "$CURRENT_TAG" ]
-then
-  echo "Stopped deployment because the tag to deploy and the one in the destination are the same."
-  circleci-agent step halt
-fi
+# Compare the commit SHA the tags points to, to make sure they are different.
+compare-tag-commits() {
+  CURRENT_TAG=$(get-current-tag)
+  echo "Current Tag on ${ACSF_ENV}: $CURRENT_TAG"
+  echo "The tag to deploy is $TAG_TO_DEPLOY"
+
+  # Get commits.
+  COMMIT_SHA_CURRENT=$(git rev-list -n 1 "$CURRENT_TAG")
+  COMMIT_SHA_DEPLOY=$(git rev-list -n 1 "$TAG_TO_DEPLOY")
+
+  echo "$CURRENT_TAG points to commit SHA: $COMMIT_SHA_CURRENT"
+  echo "$TAG_TO_DEPLOY points to commit SHA: $COMMIT_SHA_DEPLOY"
+
+  if [ "$COMMIT_SHA_CURRENT" == "$COMMIT_SHA_DEPLOY" ]
+  then
+    echo "Stopped deployment because the tag to deploy and the one in the destination are the same."
+    circleci-agent step halt
+  fi
+}
+compare-tag-commits


### PR DESCRIPTION
Merging alpha into main to create a new release with latest improvements
- Adds a `jira-project` parameter to `jira-transition` command and `deploy-tag` Job to be able to filter ticket ids for the specified Jira Project.

This just adds the jira project Key (ie: `ABC` for the ABC Jira project/board) in the grep pipe git log command. So we only retrieve those commits related to the project and we build the `JIRA_ISSUES` for the specific project.

This disables transitioning tickets for other projects that might be in the git log output.