### PR TITLE
[semver:minor] Multiple jira projects

### DIFF
--- a/src/commands/jira-transition.yml
+++ b/src/commands/jira-transition.yml
@@ -25,14 +25,14 @@ parameters:
   jira-transition-id:
     type: string
     default: ""
-    description: 'The Jira transition ID'
+    description: 'The Jira transition ID(s)'
   jira-auth:
     type: env_var_name
     default: JIRA_AUTH
   jira-project:
     type: string
     default: ""
-    description: 'The Jira Project key for which we should transition tickets.'
+    description: 'The Jira Project key(s) for which we should transition tickets.'
 steps:
   - run:
       when: on_success
@@ -45,5 +45,5 @@ steps:
         JIRA_URL: << parameters.jira-url >>
         JIRA_TRANS_ID: << parameters.jira-transition-id >>
         JIRA_AUTH_TOKEN: "$<< parameters.jira-auth >>"
-        JIRA_PROJECT: <<  parameters.jira-project >>
+        JIRA_PROJECT: << parameters.jira-project >>
       command: <<include(scripts/jira-transition.sh)>>

--- a/src/scripts/jira-transition.sh
+++ b/src/scripts/jira-transition.sh
@@ -39,16 +39,56 @@ get-current-tag() {
 CURRENT_TAG=$(get-current-tag)
 echo "Current Tag on ${ACSF_ENV}: $CURRENT_TAG"
 
-# With the the current tag, get a list of issues IDs that were committed between current and latest. Filtering by Jira Project Key.
+# Receives jira_project as argument.
+# With the current tag, get a list of issues IDs that were committed between current and latest.
+# Filtering by Jira Project Key.
 get-jira-issues() {
+  local jira_project=$1
   local JIRA_ISSUES
   if [ -n "${CURRENT_TAG}" ]; then
-    JIRA_ISSUES=$(git log "${CURRENT_TAG}".."${TAG_TO_DEPLOY}" | grep -e "${JIRA_PROJECT}-[0-9]\+" -o | sort -u | tr '\n' ',' | sed '$s/,$/\n/')
+    JIRA_ISSUES=$(git log "${CURRENT_TAG}".."${TAG_TO_DEPLOY}" | grep -e "${jira_project}-[0-9]\+" -o | sort -u | tr '\n' ',' | sed '$s/,$/\n/')
     echo "$JIRA_ISSUES"
   else
     echo "We were not able to get current tag deployed to ACSF Env. Please check the 'acsf-' parameters are correctly set."
   fi
 }
+
+# Transitions the issues for each project
+transition-project-issues() {
+  local -a jira_projects
+  local -a jira_transitions
+  IFS=" " read -r -a jira_projects <<< "${JIRA_PROJECT}"
+  IFS=" " read -r -a jira_transitions <<< "${JIRA_TRANS_ID}"
+  echo "The Project IDs: " "${jira_projects[@]}"
+  echo "The Transition IDs: " "${jira_transitions[@]}"
+  # We assume here the project and transition ids will be set in the same order, so we use the keys for each array.
+  for key in "${!jira_projects[@]}"; do
+    local jira_project=${jira_projects[$key]}
+    local jira_trans=${jira_transitions[$key]}
+
+    JIRA_ISSUES=$(get-jira-issues jira_project)
+    if [ -n "${JIRA_ISSUES}" ]; then
+      echo "Included tickets between ${CURRENT_TAG} and ${TAG_TO_DEPLOY} for Project $jira_project: ${JIRA_ISSUES}"
+      echo "export JIRA_ISSUES=$(get-jira-issues jira_project)" >> "$BASH_ENV"
+      echo "export JIRA_PROJECT=${jira_project}" >> "$BASH_ENV"
+      for issue in ${JIRA_ISSUES//,/ }
+        do
+          echo "Transitioning to $jira_trans the issue $issue..."
+          ## Transition to "Deployed to ${ACSF_ENV}".
+          curl \
+            -X POST \
+            -H "Authorization: Basic ${JIRA_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"transition": { "id": "'"${jira_trans}"'" }}' \
+            "${JIRA_URL}"/rest/api/2/issue/"$issue"/transitions
+        done
+    else
+      echo "There are no issues to transition."
+      echo 'export JIRA_ISSUES="No Tickets"' >> "$BASH_ENV"
+    fi
+  done
+}
+transition-project-issues
 
 # Jira API call to transition the issues.
 transition-issues() {
@@ -73,4 +113,5 @@ transition-issues() {
     echo 'export JIRA_ISSUES="No Tickets"' >> "$BASH_ENV"
   fi
 }
-transition-issues
+# Use transition-project-issues to test managing different Jira projects.
+#transition-issues

--- a/src/scripts/jira-transition.sh
+++ b/src/scripts/jira-transition.sh
@@ -43,10 +43,10 @@ echo "Current Tag on ${ACSF_ENV}: $CURRENT_TAG"
 # With the current tag, get a list of issues IDs that were committed between current and latest.
 # Filtering by Jira Project Key.
 get-jira-issues() {
-  local jira_project=$1
+  local jira_project_id=$1
   local JIRA_ISSUES
   if [ -n "${CURRENT_TAG}" ]; then
-    JIRA_ISSUES=$(git log "${CURRENT_TAG}".."${TAG_TO_DEPLOY}" | grep -e "${jira_project}-[0-9]\+" -o | sort -u | tr '\n' ',' | sed '$s/,$/\n/')
+    JIRA_ISSUES=$(git log "${CURRENT_TAG}".."${TAG_TO_DEPLOY}" | grep -e "${jira_project_id}-[0-9]\+" -o | sort -u | tr '\n' ',' | sed '$s/,$/\n/')
     echo "$JIRA_ISSUES"
   else
     echo "We were not able to get current tag deployed to ACSF Env. Please check the 'acsf-' parameters are correctly set."
@@ -63,17 +63,17 @@ transition-project-issues() {
   echo "The Transition IDs: " "${jira_transitions[@]}"
   # We assume here the project and transition ids will be set in the same order, so we use the keys for each array.
   for key in "${!jira_projects[@]}"; do
-    local jira_project=${jira_projects[$key]}
+    local jira_project_id=${jira_projects[$key]}
     local jira_trans=${jira_transitions[$key]}
 
-    JIRA_ISSUES=$(get-jira-issues jira_project)
+    JIRA_ISSUES=$(get-jira-issues jira_project_id)
     echo "The Jira Issues ids in JIRA_ISSUES: $JIRA_ISSUES"
-    echo "The Jira Project ID in jira_project: $jira_project"
+    echo "The Jira Project ID in jira_project_id: $jira_project_id"
     if [ -n "${JIRA_ISSUES}" ]; then
-      echo "Included tickets between ${CURRENT_TAG} and ${TAG_TO_DEPLOY} for Project $jira_project: ${JIRA_ISSUES}"
+      echo "Included tickets between ${CURRENT_TAG} and ${TAG_TO_DEPLOY} for Project $jira_project_id: ${JIRA_ISSUES}"
       # @todo: We might need to append here so we don't get the last project overriding these vars.
-      echo "export JIRA_ISSUES=$(get-jira-issues jira_project)" >> "$BASH_ENV"
-      echo "export JIRA_PROJECT=${jira_project}" >> "$BASH_ENV"
+      echo "export JIRA_ISSUES=$(get-jira-issues jira_project_id)" >> "$BASH_ENV"
+      echo "export JIRA_PROJECT=${jira_project_id}" >> "$BASH_ENV"
       for issue in ${JIRA_ISSUES//,/ }
         do
           echo "Transitioning to $jira_trans the issue $issue..."

--- a/src/scripts/jira-transition.sh
+++ b/src/scripts/jira-transition.sh
@@ -67,8 +67,11 @@ transition-project-issues() {
     local jira_trans=${jira_transitions[$key]}
 
     JIRA_ISSUES=$(get-jira-issues jira_project)
+    echo "The Jira Issues ids in JIRA_ISSUES: $JIRA_ISSUES"
+    echo "The Jira Project ID in jira_project: $jira_project"
     if [ -n "${JIRA_ISSUES}" ]; then
       echo "Included tickets between ${CURRENT_TAG} and ${TAG_TO_DEPLOY} for Project $jira_project: ${JIRA_ISSUES}"
+      # @todo: We might need to append here so we don't get the last project overriding these vars.
       echo "export JIRA_ISSUES=$(get-jira-issues jira_project)" >> "$BASH_ENV"
       echo "export JIRA_PROJECT=${jira_project}" >> "$BASH_ENV"
       for issue in ${JIRA_ISSUES//,/ }
@@ -87,6 +90,9 @@ transition-project-issues() {
       echo 'export JIRA_ISSUES="No Tickets"' >> "$BASH_ENV"
     fi
   done
+  echo "-- After transitioning issues and exporting BASH_ENV --"
+  echo "The Jira Issues ids in JIRA_ISSUES: $JIRA_ISSUES"
+  echo "The Jira Project ID in JIRA_PROJECT: $JIRA_PROJECT"
 }
 transition-project-issues
 


### PR DESCRIPTION
Adds (or tries to add) the possibility to use several Jira Projects and thus several transition ids.
- `jira-project` 
- `jira-transition-id` 
Parameters are strings, but we support adding more than one id separated by a space, example:

```yaml
- acsf/deploy-tag:
    name: dev-deploy
    pre-steps:
      - pr-semver/get-last-tag
    tag: $LAST_TAG
    acsf-user: "theuser"
    acsf-site: "thesite"
    acsf-env: "theenv"
    acsf-deploy-type: "code, db"
    slack-channel: "slackchannelID"
    jira-url: "https://the.jira.url"
    jira-project: "KEY1 KEY2" #----> Provides two different project keys.
    jira-transition-id: "01 03" #--> Two different transition ids, 01 transition id for KEY1 project, 02 for KEY2
    img-version: "8.0-latest"
```